### PR TITLE
ADD: PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+# Description
+Please provide a summary of the changes and the related issue. Include relevant motivation, context, and a high-level overview of the approach taken to address the problem.
+
+## Jira Story
+Link to the corresponding Jira story: [DOP-1234](link_to_jira_story)
+
+## Type of Change
+Please tag this PR with one or more of the following labels:
+- [ ] `bug`: non-breaking change that fixes an issue.
+- [ ] `enhancement`: non-breaking change that adds functionality.
+- [ ] `breaking-change`: fix or feature that would cause existing functionality to not work as expected.
+- [ ] `documentation`: this change requires a documentation update.
+
+# Testing
+Please describe the tests that you added or ran to verify your changes. If no tests were added or run, provide an explanation as to why.
+
+## Test Plan
+- [ ] I have added/updated unit tests for the changes made.
+- [ ] I have added/updated integration tests for the changes made.
+
+### Unit Tests Added/Updated
+- [ ] Test A: Description of test A
+- [ ] Test B: Description of test B
+- [ ] ...
+
+### Integration Tests Added/Updated
+- [ ] Test X: Description of test X
+- [ ] Test Y: Description of test Y
+- [ ] ...
+
+### Manual Testing
+Describe any additional manual tests performed and their results. If manual testing is not applicable remove this section.
+
+## Checklist
+- [ ] I have performed a self-review of my code.
+- [ ] I have updated the `requirements.txt` file, if required.
+- [ ] My code is easy to read and understand, particularly in complicated areas.
+- [ ] I have made corresponding changes to the documentation (README, docstrings, etc.).
+- [ ] New and existing unit tests pass locally with my changes.
+
+# Deployment and Release Checklist (if applicable)
+- [ ] Deployment scripts and configurations have been updated, if required.
+- [ ] Any necessary environment variables or configuration changes have been documented.


### PR DESCRIPTION
Adding PR template to .github repository. Will be used as the default template in all repositories within the GitHub organization. This default template can be overwritten in particular repositories by adding a tailored PR template to the repository in question.