### PR TITLE
Add Jira link; remove 1 item from Checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 Please provide a summary of the changes and the related issue. Include relevant motivation, context, and a high-level overview of the approach taken to address the problem.
 
 ## Jira Story
-Link to the corresponding Jira story: [DOP-1234](link_to_jira_story)
+Link to the corresponding Jira story: [DOP-1234](https://ideon-technologies.atlassian.net/browse/DOP-XXXX)
 
 ## Type of Change
 Please tag this PR with one or more of the following labels:
@@ -34,7 +34,6 @@ Describe any additional manual tests performed and their results. If manual test
 ## Checklist
 - [ ] I have performed a self-review of my code.
 - [ ] I have updated the `requirements.txt` file if required.
-- [ ] My code is easy to read and understand, particularly in complicated areas.
 - [ ] I have made corresponding changes to the documentation (README, docstrings, etc.).
 - [ ] New and existing unit tests pass locally with my changes.
 


### PR DESCRIPTION
* Added a link to the jira, such that to update a description of a task it wouldn't be necessary to go to Jira and copy the link
* Removed an item from checklist, which duplicates the first one in my opinion. Please, @GuusLammers, feel free to leave the "- [ ] My code is easy to read and understand, particularly in complicated areas." point, if you feel like it.