### PR TITLE
Add here our default config for release notes generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-in-release-notes
+      - duplicate
+  categories:
+    - title: Breaking Changes 🚨
+      labels:
+        - breaking-change
+    - title: New Features 🆕
+      labels:
+        - new-feature
+    - title: Bug Fixes 🪲
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
# Description
The same config is used in the "main 4" repos, but not in all of them, e.g. I need one for `ic-environment`, so decided to add it for all the repos.

