### PR TITLE
Update pull_request_template.md - add before/after screenshots

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,13 @@ Please provide a summary of the changes and the related issue. Include relevant 
 ## Jira Story
 Link to the corresponding Jira story: [DOP-1234](https://ideon-technologies.atlassian.net/browse/DOP-XXXX)
 
+## Screenshots
+Please add screenshots of the application before your changes with context for the problem, and after your changes with your proposed solution. You can add arrows or shapes to highlight the change/s being made.
+
+Before:
+
+After:
+
 ## Type of Change
 Please tag this PR with one or more of the following labels:
 - [ ] `bug`: non-breaking change that fixes an issue.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,11 +5,15 @@ Please provide a summary of the changes and the related issue. Include relevant 
 Link to the corresponding Jira story: [DOP-1234](https://ideon-technologies.atlassian.net/browse/DOP-XXXX)
 
 ## Screenshots
-Please add screenshots of the application before your changes with context for the problem, and after your changes with your proposed solution. You can add arrows or shapes to highlight the change/s being made.
+Please include screenshots of the application before and after your changes. Ensure to provide context for the problem and how your changes address it. Feel free to use arrows or shapes to highlight the areas affected.
 
 Before:
 
+_(Provide a screenshot of the application before your changes)_
+
 After:
+
+_(Provide a screenshot of the application after your changes)_
 
 ## Type of Change
 Please tag this PR with one or more of the following labels:


### PR DESCRIPTION
# Description
This came from a suggestion by @mishareyes after a meeting with @guuslammers @vladyvr @mdmuon and @SogandHSalimi 
Adding a section for before/after screenshots can help reviewers understand the context from *before changes*, and highlight the proposed solution *after changes*

Feel free to comment on the wording of the change or the placement of the change. thanks 🌟🎊 

![image](https://github.com/user-attachments/assets/c09da0a9-d296-42ab-8fe7-88f98eac58ad)
